### PR TITLE
fix: Extended budgets so that npm builds successfully

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,8 +37,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "2mb",
+                  "maximumError": "3mb"
                 },
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
fix: I extended both the warning and error budgets, to stop warnings from being printed and to enable the npm build to continue to completion.